### PR TITLE
feat: align previous version status validation with backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "ts-loader": "^9.5.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.7.3",
-        "vscode-extension-tester": "^8.23.0",
+        "vscode-extension-tester": "^8.24.0",
         "vscode-test": "^1.6.1",
         "webpack": "^5.98.0",
         "webpack-cli": "^6.0.1"
@@ -803,9 +803,9 @@
       }
     },
     "node_modules/@redhat-developer/locators": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@redhat-developer/locators/-/locators-1.20.0.tgz",
-      "integrity": "sha512-SvS9lABIHDpTU0w7jTN3qsMxDSceAbbc3j0xba9Cd8xrDEMWpysnvt3WY4vtYalikMhXtkcSAf3L3adYTS7iqg==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@redhat-developer/locators/-/locators-1.21.0.tgz",
+      "integrity": "sha512-mPXkQrkoDhhA5bN8O7dHsHYZzLLjJ66lmjOUVnoG3OqCRUMwKRVjjrbilVHZICidBU08htz0OUHgkDsMQEhzGw==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -814,17 +814,16 @@
       }
     },
     "node_modules/@redhat-developer/page-objects": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@redhat-developer/page-objects/-/page-objects-1.20.0.tgz",
-      "integrity": "sha512-akY6gXRbUmlf2Cayp1A/TwoT0/eyK+/LReSBo7Nmfotk7QfR262k7ZilAmL3Vf/jmX3Gg0D8UrDZRFk8RTxS2Q==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@redhat-developer/page-objects/-/page-objects-1.21.0.tgz",
+      "integrity": "sha512-ACPPLlKQZWI0BMMsuQC2U8LvhKbEpatocVCWQJR0cELWUZuOOAvfn3byFfCuLN5bt7Z966tUnS+oCtDsO1byVQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "clipboardy": "^5.3.1",
+        "clipboardy": "^5.3.2",
         "clone-deep": "^4.0.1",
         "compare-versions": "^6.1.1",
-        "fs-extra": "^11.3.4",
-        "type-fest": "^4.41.0"
+        "fs-extra": "^11.4.0"
       },
       "peerDependencies": {
         "selenium-webdriver": ">=4.6.1",
@@ -1013,13 +1012,13 @@
       }
     },
     "node_modules/@sindresorhus/is": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
-      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-8.1.0.tgz",
+      "integrity": "sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
@@ -1355,9 +1354,9 @@
       "license": "MIT"
     },
     "node_modules/@types/selenium-webdriver": {
-      "version": "4.35.5",
-      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-4.35.5.tgz",
-      "integrity": "sha512-wCQCjWmahRkUAO7S703UAvBFkxz4o/rjX4T2AOSWKXSi0sTQPsrXxR0GjtFUT0ompedLkYH4R5HO5Urz0hyeog==",
+      "version": "4.35.6",
+      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-4.35.6.tgz",
+      "integrity": "sha512-8nfyMRi4VvkY9QrQGyY/zkleAhnjnmE8YtdEeoCrWe3izp1P9vo9f5VTNRYF0up+l+kn+VuZah+je+bLddNV+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1912,9 +1911,9 @@
       }
     },
     "node_modules/@vscode/vsce": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.1.tgz",
-      "integrity": "sha512-MPn5p+DoudI+3GfJSpAZZraE1lgLv0LcwbH3+xy7RgEhty3UIkmUMUA+5jPTDaxXae00AnX5u77FxGM8FhfKKA==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.2.tgz",
+      "integrity": "sha512-XSxMosEEDO6vLxELAHVkwmhC0qe0ijZni2jB9Rcs8kQsW4lhTDQ/wMzmwFs/buotAWSnpmUp/dRWD2ufG3UYKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1930,13 +1929,13 @@
         "cockatiel": "^3.1.2",
         "commander": "^12.1.0",
         "form-data": "^4.0.0",
-        "glob": "^11.0.0",
+        "glob": "^13.0.6",
         "hosted-git-info": "^4.0.2",
         "jsonc-parser": "^3.2.0",
         "leven": "^3.1.0",
         "markdown-it": "^14.1.0",
         "mime": "^1.3.4",
-        "minimatch": "^3.0.3",
+        "minimatch": "^10.2.2",
         "parse-semver": "^1.1.1",
         "read": "^1.0.7",
         "secretlint": "^10.1.2",
@@ -2103,28 +2102,61 @@
         "win32"
       ]
     },
-    "node_modules/@vscode/vsce/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+    "node_modules/@vscode/vsce/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
+      "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/@vscode/vsce/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+    "node_modules/@vscode/vsce/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -2483,9 +2515,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3265,6 +3297,19 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/chunk-data": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chunk-data/-/chunk-data-0.1.0.tgz",
+      "integrity": "sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -3314,9 +3359,9 @@
       }
     },
     "node_modules/clipboardy": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-5.3.1.tgz",
-      "integrity": "sha512-fPWgBqpp9ctiOQCkE5yjYGzv11ZU55g6ahEgr3COiio6dXdt1mbchCPXQrSR2Y9sZqfi8L7QD3+UosgXVIuPdg==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-5.3.2.tgz",
+      "integrity": "sha512-R35PENCHFCw6lsd5SjYPuAVV3Zawr74mKc7ogFNzoDPoQsmWDoJgUNNnWCk/czeqdZGZs8Y0M8zkOlVoySfHEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4992,16 +5037,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/form-data-encoder": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.1.0.tgz",
-      "integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -5030,9 +5065,9 @@
       "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5381,27 +5416,27 @@
       }
     },
     "node_modules/got": {
-      "version": "14.6.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-14.6.6.tgz",
-      "integrity": "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-15.1.0.tgz",
+      "integrity": "sha512-DG+DAAkRtno+oDr/GBsliAkhN9+zczOPM5qXk3efDZY3qvyRnZU+NwQlb/IOY6cSnxxTR9z3aHCcShJyjb0hJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sindresorhus/is": "^7.0.1",
+        "@sindresorhus/is": "^8.0.0",
         "byte-counter": "^0.1.0",
         "cacheable-lookup": "^7.0.0",
-        "cacheable-request": "^13.0.12",
+        "cacheable-request": "^13.0.18",
+        "chunk-data": "^0.1.0",
         "decompress-response": "^10.0.0",
-        "form-data-encoder": "^4.0.2",
         "http2-wrapper": "^2.2.1",
-        "keyv": "^5.5.3",
-        "lowercase-keys": "^3.0.0",
-        "p-cancelable": "^4.0.1",
+        "keyv": "^5.6.0",
+        "lowercase-keys": "^4.0.1",
         "responselike": "^4.0.2",
-        "type-fest": "^4.26.1"
+        "type-fest": "^5.6.0",
+        "uint8array-extras": "^1.5.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
@@ -5441,6 +5476,22 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/got/node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6624,13 +6675,13 @@
       }
     },
     "node_modules/lowercase-keys": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-4.0.1.tgz",
+      "integrity": "sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7554,16 +7605,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-cancelable": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-4.0.1.tgz",
-      "integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8389,6 +8430,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/responselike/node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -8666,9 +8720,9 @@
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
       "dev": true,
       "license": "WTFPL OR ISC",
       "dependencies": {
@@ -8725,9 +8779,9 @@
       }
     },
     "node_modules/selenium-webdriver": {
-      "version": "4.43.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.43.0.tgz",
-      "integrity": "sha512-dV4zBTT37or3Z3/8uD6rS8zvd4ZxPuG4EJVlqYIbZCGZCYttZm7xb9rlFLSk4rrsQHAeDYvudl7cquo0vWpHjg==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.47.0.tgz",
+      "integrity": "sha512-nxxJnH25tsJxz+pdMxtvH89tbrMnfff6W//uBIVlOWz1KZlADiQ7dyRPehknKdYiC3HwEypTy1l+tozxO0I2Qw==",
       "dev": true,
       "funding": [
         {
@@ -8743,11 +8797,11 @@
       "dependencies": {
         "@bazel/runfiles": "^6.5.0",
         "jszip": "^3.10.1",
-        "tmp": "^0.2.5",
-        "ws": "^8.20.0"
+        "tmp": "^0.2.7",
+        "ws": "^8.21.3"
       },
       "engines": {
-        "node": ">= 20.0.0"
+        "node": ">= 22.0.0"
       }
     },
     "node_modules/semver": {
@@ -9304,13 +9358,13 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -9538,6 +9592,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tapable": {
@@ -9919,9 +9986,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10217,6 +10284,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -10457,29 +10537,29 @@
       }
     },
     "node_modules/vscode-extension-tester": {
-      "version": "8.23.0",
-      "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-8.23.0.tgz",
-      "integrity": "sha512-YElhRDkOjvmGFv44aCMnEnUM5RmFqWByQ8TBr7/6N9K/b5o1gu2fo9EgTef6VmrB4kyFnSrkPVAbiZBfKQA1mQ==",
+      "version": "8.24.0",
+      "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-8.24.0.tgz",
+      "integrity": "sha512-ek75O8g1xg/LTmDQCDv8rr7xTB2DgaLQjJKDO1pecqn0NqQhleYJmsO7K5K0/DwrPK2hK1703d6qEzCQzqvYIw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@redhat-developer/locators": "^1.20.0",
-        "@redhat-developer/page-objects": "^1.20.0",
-        "@types/selenium-webdriver": "^4.35.5",
-        "@vscode/vsce": "^3.7.1",
-        "c8": "^11.0.0",
+        "@redhat-developer/locators": "^1.21.0",
+        "@redhat-developer/page-objects": "^1.21.0",
+        "@types/selenium-webdriver": "^4.35.6",
+        "@vscode/vsce": "^3.9.2",
+        "c8": "^12.0.0",
         "commander": "^14.0.3",
         "compare-versions": "^6.1.1",
         "find-up": "8.0.0",
-        "fs-extra": "^11.3.4",
+        "fs-extra": "^11.4.0",
         "glob": "^13.0.6",
-        "got": "^14.6.6",
+        "got": "^15.1.0",
         "hpagent": "^1.2.0",
-        "js-yaml": "^4.1.1",
-        "sanitize-filename": "^1.6.3",
-        "selenium-webdriver": "^4.41.0",
+        "js-yaml": "^5.2.2",
+        "sanitize-filename": "^1.6.4",
+        "selenium-webdriver": "^4.46.0",
         "targz": "^1.0.1",
-        "unzipper": "^0.12.3"
+        "unzipper": "^0.12.5"
       },
       "bin": {
         "extest": "out/cli.js"
@@ -10497,6 +10577,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/vscode-extension-tester/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/vscode-extension-tester/node_modules/balanced-match": {
@@ -10517,22 +10610,22 @@
       "license": "MIT"
     },
     "node_modules/vscode-extension-tester/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/vscode-extension-tester/node_modules/c8": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-11.0.0.tgz",
-      "integrity": "sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-12.0.0.tgz",
+      "integrity": "sha512-4zpJvrd1nKWutnnKC2pXkFmb6iM1l+ffN//o1CzlTNwW7GSOs9a1xrLqkC48nU8oEkjmPZLPiwMsIaOvoF4Pqg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -10545,14 +10638,14 @@
         "istanbul-reports": "^3.1.6",
         "test-exclude": "^8.0.0",
         "v8-to-istanbul": "^9.0.0",
-        "yargs": "^17.7.2",
+        "yargs": "^18.0.0",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
         "c8": "bin/c8.js"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       },
       "peerDependencies": {
         "monocart-coverage-reports": "^2"
@@ -10580,6 +10673,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/vscode-extension-tester/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/vscode-extension-tester/node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/vscode-extension-tester/node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -10589,6 +10715,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/vscode-extension-tester/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vscode-extension-tester/node_modules/find-up": {
       "version": "8.0.0",
@@ -10641,14 +10774,37 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/vscode-extension-tester/node_modules/js-yaml": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
+      "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
     "node_modules/vscode-extension-tester/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -10689,6 +10845,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/vscode-extension-tester/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/vscode-extension-tester/node_modules/test-exclude": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
@@ -10705,17 +10878,96 @@
       }
     },
     "node_modules/vscode-extension-tester/node_modules/unzipper": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
-      "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.5.tgz",
+      "integrity": "sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bluebird": "~3.7.2",
         "duplexer2": "~0.1.4",
-        "fs-extra": "^11.2.0",
+        "fs-extra": "11.3.1",
         "graceful-fs": "^4.2.2",
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/vscode-extension-tester/node_modules/unzipper/node_modules/fs-extra": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/vscode-extension-tester/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/vscode-extension-tester/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vscode-extension-tester/node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/vscode-extension-tester/node_modules/yargs/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/vscode-extension-tester/node_modules/yocto-queue": {
@@ -11116,9 +11368,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11338,9 +11590,9 @@
       }
     },
     "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@typescript-eslint/eslint-plugin": "^8.17.0",
         "@typescript-eslint/parser": "^8.17.0",
         "@vscode/test-cli": "^0.0.10",
-        "@vscode/test-electron": "^2.4.1",
+        "@vscode/test-electron": "^3.1.0",
         "@vscode/vsce": "^3.2.2",
         "body-parser": "^2.2.0",
         "chai": "^4.4.1",
@@ -1895,20 +1895,20 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.4.1.tgz",
-      "integrity": "sha512-Gc6EdaLANdktQ1t+zozoBVRynfIsMKMc94Svu1QreOBC8y76x4tvaK32TljrLi1LI2+PK58sDVbL7ALdqf3VRQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.5",
         "jszip": "^3.10.1",
-        "ora": "^7.0.1",
+        "ora": "^8.1.0",
         "semver": "^7.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@vscode/vsce": {
@@ -2639,7 +2639,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/big-integer": {
       "version": "1.6.52",
@@ -2692,33 +2693,6 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/bl": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
-      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/bluebird": {
@@ -2872,31 +2846,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-alloc": {
@@ -3317,16 +3266,16 @@
       }
     },
     "node_modules/cli-cursor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "restore-cursor": "^4.0.0"
+        "restore-cursor": "^5.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5214,6 +5163,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-func-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
@@ -5731,7 +5693,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -6864,6 +6827,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -7474,33 +7450,33 @@
       }
     },
     "node_modules/ora": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-7.0.1.tgz",
-      "integrity": "sha512-0TUxTiFJWv+JnjWm4o9yvuskpEJLXTcng8MJuKd+SzAzp2o+OP3HWqNhB4OdJRt1Vsd9/mR0oyaEYlOnL7XIRw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
-        "cli-cursor": "^4.0.0",
-        "cli-spinners": "^2.9.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
         "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^1.3.0",
-        "log-symbols": "^5.1.0",
-        "stdin-discarder": "^0.1.0",
-        "string-width": "^6.1.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
         "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ora/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7511,13 +7487,43 @@
       }
     },
     "node_modules/ora/node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ora/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols/node_modules/is-unicode-supported": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
       "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
@@ -7530,36 +7536,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ora/node_modules/log-symbols": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
-      "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.0.0",
-        "is-unicode-supported": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ora/node_modules/string-width": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-6.1.0.tgz",
-      "integrity": "sha512-k01swCJAgQmuADB0YIc+7TuatfNvTBVOoaUWJjTB9R4VJzR5vNWzf5t42ESVZFPS8xTySF7CAdV4t/aaIm3UnQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^10.2.1",
-        "strip-ansi": "^7.0.1"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8401,28 +8390,37 @@
       }
     },
     "node_modules/restore-cursor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/restore-cursor/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -9200,16 +9198,13 @@
       }
     },
     "node_modules/stdin-discarder": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
-      "integrity": "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "bl": "^5.0.0"
-      },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "test:compile": "tsc -p . --outDir out",
     "test:watch": "tsc -watch -p ./",
     "test:unit": "node ./out/test/runTest.js",
-    "test:ui": "extest setup-and-run './out/ui-test/*.test.js' --code_settings settings.json --extensions_dir .test-extensions",
+    "test:ui": "extest setup-and-run './out/ui-test/*.test.js' --code_version 1.131.0 --code_settings settings.json --extensions_dir .test-extensions",
     "test:ui-and-be": "concurrently --kill-others --success first  \"npm run dev:backend\" \"npm run test:ui\"",
     "update-lock-file": "update-lock-file @netcracker"
   },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@typescript-eslint/eslint-plugin": "^8.17.0",
     "@typescript-eslint/parser": "^8.17.0",
     "@vscode/test-cli": "^0.0.10",
-    "@vscode/test-electron": "^2.4.1",
+    "@vscode/test-electron": "^3.1.0",
     "@vscode/vsce": "^3.2.2",
     "body-parser": "^2.2.0",
     "chai": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "test:compile": "tsc -p . --outDir out",
     "test:watch": "tsc -watch -p ./",
     "test:unit": "node ./out/test/runTest.js",
-    "test:ui": "extest setup-and-run './out/ui-test/*.test.js' --code_version 1.131.0 --code_settings settings.json --extensions_dir .test-extensions",
+    "test:ui": "extest setup-and-run './out/ui-test/*.test.js' --code_settings settings.json --extensions_dir .test-extensions",
     "test:ui-and-be": "concurrently --kill-others --success first  \"npm run dev:backend\" \"npm run test:ui\"",
     "update-lock-file": "update-lock-file @netcracker"
   },

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.3",
-    "vscode-extension-tester": "^8.23.0",
+    "vscode-extension-tester": "^8.24.0",
     "vscode-test": "^1.6.1",
     "webpack": "^5.98.0",
     "webpack-cli": "^6.0.1"

--- a/resources/template/js/main.js
+++ b/resources/template/js/main.js
@@ -174,7 +174,7 @@ const updateOptions = (fieldName, options) => {
         const optionElement = document.createElement('vscode-option');
         optionElement.value = option.name;
         optionElement.selected = option.selected;
-        optionElement.innerHTML = option.name;
+        optionElement.innerHTML = option.label ?? option.name;
         if (option.disabled) {
             optionElement.setAttribute(DISABLED_ATTRIBUTE, '');
         }

--- a/resources/template/js/publishing.js
+++ b/resources/template/js/publishing.js
@@ -6,9 +6,36 @@
         VERSION: 'version',
         STATUS: 'status',
         PREVIOUS_VERSION: 'previousVersion',
+        PREVIOUS_VERSION_LABEL: 'previousVersionLabel',
+        PREVIOUS_VERSION_GROUP: 'previousVersionGroup',
         LABELS: 'labels',
         PUBLISHING_BUTTON: 'publishing-button'
     };
+
+
+    const LABEL_TEXT_FIELD_TYPE = 'label-text';
+    updateFieldMapper.set(LABEL_TEXT_FIELD_TYPE, (fieldName, value) => {
+        const field = getField(fieldName);
+        if (!field) {
+            return;
+        }
+        field.textContent = value;
+    });
+    typeFieldMapper.set(PublishingFields.PREVIOUS_VERSION_LABEL, LABEL_TEXT_FIELD_TYPE);
+
+    const TITLE_FIELD_TYPE = 'title-text';
+    updateFieldMapper.set(TITLE_FIELD_TYPE, (fieldName, value) => {
+        const field = getField(fieldName);
+        if (!field) {
+            return;
+        }
+        if (value) {
+            field.setAttribute('title', value);
+        } else {
+            field.removeAttribute('title');
+        }
+    });
+    typeFieldMapper.set(PublishingFields.PREVIOUS_VERSION_GROUP, TITLE_FIELD_TYPE);
 
     typeFieldMapper.set(PublishingFields.PACKAGE_ID, FieldTypes.INPUT);
     typeFieldMapper.set(PublishingFields.VERSION, FieldTypes.INPUT);

--- a/server/data/versions.ts
+++ b/server/data/versions.ts
@@ -35,3 +35,20 @@ export const VERSIONS: PublishingVersion[] = [
         previousVersion: ''
     }
 ];
+
+export const RELEASE_VERSIONS: PublishingVersion[] = [
+    {
+        version: `${VERSION_1}@1`,
+        status: 'release',
+        createdAt: '2025-03-11T10:38:41.00982Z',
+        createdBy: {
+            avatarUrl: '',
+            email: 'userEmail',
+            id: 'userId',
+            name: 'userName',
+            type: 'user'
+        },
+        versionLabels: [],
+        previousVersion: ''
+    }
+];

--- a/server/routers/package-router.ts
+++ b/server/routers/package-router.ts
@@ -4,11 +4,12 @@ import {
     PublishingConfig,
     PublishingStatus,
     PublishingStatusDto,
+    PublishingVersion,
     PublishingVersionDto,
     PublishingViewPackageIdData
 } from '../../src/common/models/publishing.model';
-import { PACKAGE_ID_NAME, PACKAGES_DATA } from '../data/packages';
-import { VERSIONS } from '../data/versions';
+import { PACKAGE_ID_NAME, PACKAGE_ID_RELEASE_NAME, PACKAGE_ID_VERSIONS_NAME, PACKAGES_DATA } from '../data/packages';
+import { RELEASE_VERSIONS, VERSIONS } from '../data/versions';
 import multer from 'multer';
 import { BUILD_CONFIGS } from '../data/build-config';
 import { PUBLISH_ID } from '../data/publish';
@@ -28,10 +29,16 @@ export function PackageRouter(): PackageRouter {
     return router;
 }
 
+const VERSIONS_BY_PACKAGE: Record<string, PublishingVersion[]> = {
+    [PACKAGE_ID_NAME]: VERSIONS,
+    [PACKAGE_ID_VERSIONS_NAME]: VERSIONS,
+    [PACKAGE_ID_RELEASE_NAME]: RELEASE_VERSIONS
+};
+
 export function getVersions(router: PackageRouter): void {
     router.get('/:packageId/versions/', (req, res) => {
         const packageId = req.params.packageId;
-        res.status(200).json(packageId === PACKAGE_ID_NAME ? ({ versions: VERSIONS } as PublishingVersionDto) : []);
+        res.status(200).json({ versions: VERSIONS_BY_PACKAGE[packageId] ?? [] } as PublishingVersionDto);
     });
 }
 

--- a/src/common/constants/publishing.constants.ts
+++ b/src/common/constants/publishing.constants.ts
@@ -4,7 +4,16 @@ export const ARCHIVED = 'archived';
 export const PUBLISHING_STATUSES = [DRAFT, RELEASE, ARCHIVED];
 export const PUBLISHING_JS_PATH = 'publishing.js';
 export const PUBLISHING_INPUT_DEFAULT_PATTERN = '^[A-Za-z0-9_.~\\- ]{1,}$';
+
 export const PUBLISHING_NO_PREVIOUS_VERSION = 'No previous release version';
+export const PUBLISHING_VERSIONS_LIMIT = '100';
+export const PUBLISHING_PREVIOUS_VERSION_LABEL = 'Previous version:';
+export const PUBLISHING_PREVIOUS_RELEASE_VERSION_LABEL = 'Previous release version:';
+export const PUBLISHING_NO_PREVIOUS_VERSION_TEXT = 'No previous version';
+export const PUBLISHING_NO_PREVIOUS_RELEASE_VERSION_TEXT = 'No previous release version';
+
+export const PUBLISHING_RELEASE_PREVIOUS_VERSION_REQUIRED =
+    'A release version must have a release previous version';
 export const PUBLISHING_LOADING_OPTION = 'Loading...';
 
 export const PUBLISHING_WEBVIEW = 'publishingWebview';

--- a/src/common/constants/publishing.constants.ts
+++ b/src/common/constants/publishing.constants.ts
@@ -12,6 +12,9 @@ export const PUBLISHING_PREVIOUS_RELEASE_VERSION_LABEL = 'Previous release versi
 export const PUBLISHING_NO_PREVIOUS_VERSION_TEXT = 'No previous version';
 export const PUBLISHING_NO_PREVIOUS_RELEASE_VERSION_TEXT = 'No previous release version';
 
+export const PUBLISHING_PREVIOUS_VERSIONS_LOAD_ERROR =
+    'Failed to load the list of previous versions. Check the APIHUB connection and try again.';
+
 export const PUBLISHING_RELEASE_PREVIOUS_VERSION_REQUIRED =
     'A release version must have a release previous version';
 export const PUBLISHING_LOADING_OPTION = 'Loading...';

--- a/src/common/cruds/crud.service.ts
+++ b/src/common/cruds/crud.service.ts
@@ -1,6 +1,7 @@
 import { BodyInit } from 'undici-types';
 import { Disposable } from 'vscode';
 import { API_V1, API_V2, API_V3, PACKAGES, PAT_HEADER } from '../constants/common.constants';
+import { PUBLISHING_VERSIONS_LIMIT } from '../constants/publishing.constants';
 import { CrudError, CrudResponse, DefaultError, ServerStatusDto } from '../models/common.model';
 import {
     PackageId,
@@ -46,14 +47,19 @@ export class CrudService extends Disposable {
         return this.get(RequestNames.GET_SYSTEM_INFO, this.buildUrl(baseUrl, API_V1, 'system/info'), authorization);
     }
 
-    public getVersions(baseUrl: string, authorization: string, packageId: PackageId): Promise<PublishingVersionDto> {
+    public getVersions(
+        baseUrl: string,
+        authorization: string,
+        packageId: PackageId,
+        statuses: VersionStatus[]
+    ): Promise<PublishingVersionDto> {
         const url = this.buildUrl(
             baseUrl,
             API_V3,
             `${PACKAGES}/${packageId}/versions`,
             new URLSearchParams({
-                status: VersionStatus.RELEASE,
-                limit: '100',
+                status: statuses.join(','),
+                limit: PUBLISHING_VERSIONS_LIMIT,
                 page: '0'
             })
         );

--- a/src/common/models/publishing.model.ts
+++ b/src/common/models/publishing.model.ts
@@ -55,6 +55,8 @@ export enum PublishingFields {
     VERSION = 'version',
     STATUS = 'status',
     PREVIOUS_VERSION = 'previousVersion',
+    PREVIOUS_VERSION_LABEL = 'previousVersionLabel',
+    PREVIOUS_VERSION_GROUP = 'previousVersionGroup',
     LABELS = 'labels',
     PUBLISHING_BUTTON = 'publishing-button'
 }

--- a/src/common/models/webview.model.ts
+++ b/src/common/models/webview.model.ts
@@ -23,6 +23,7 @@ export interface WebviewOption {
     name: string;
     disabled: boolean;
     selected: boolean;
+    label?: string;
 }
 
 export interface WebviewPayload<T> {

--- a/src/common/webview/publishing-view.ts
+++ b/src/common/webview/publishing-view.ts
@@ -357,7 +357,7 @@ export class PublishingViewProvider extends WebviewBase<PublishingFields> {
                 packageId,
                 getPreviousVersionStatuses(status)
             );
-            const versions = dto.versions.map((version) => splitVersion(version.version).version);
+            const versions = (dto?.versions ?? []).map((version) => splitVersion(version.version).version);
 
             const options = Array.from(new Set([PUBLISHING_NO_PREVIOUS_VERSION, ...versions]));
             this.allowedPreviousVersions = options;

--- a/src/common/webview/publishing-view.ts
+++ b/src/common/webview/publishing-view.ts
@@ -29,6 +29,7 @@ import {
     PUBLISHING_NO_PREVIOUS_VERSION,
     PUBLISHING_NO_PREVIOUS_VERSION_TEXT,
     PUBLISHING_PREVIOUS_RELEASE_VERSION_LABEL,
+    PUBLISHING_PREVIOUS_VERSIONS_LOAD_ERROR,
     PUBLISHING_PREVIOUS_VERSION_LABEL,
     PUBLISHING_RELEASE_PREVIOUS_VERSION_REQUIRED,
     PUBLISHING_STATUSES,
@@ -58,6 +59,9 @@ import { debounce, isMatchingPattern } from '../../utils/common.utils';
 export class PublishingViewProvider extends WebviewBase<PublishingFields> {
     private readonly _publishingViewData: Map<WorkfolderPath, PublishingViewData> = new Map();
     private allowedPreviousVersions: VersionId[] | undefined;
+    // True while the allowed set is being (re)loaded. Publishing stays blocked meanwhile: until the
+    // response arrives the form cannot tell whether the selected previous version is still allowed.
+    private arePreviousVersionsLoading = false;
     private dependentFieldsDisabled = true;
     private readonly updateLabelsDebounced = debounce((data: PublishingViewData, version: VersionId) =>
         this.wrapInProgress(async () => await this.updateLabels(data, version))
@@ -213,6 +217,7 @@ export class PublishingViewProvider extends WebviewBase<PublishingFields> {
                 this.updateVersionPattern(publishingViewData, status);
                 this.updatePreviousVersionWording(status);
                 if (!hasSamePreviousVersionScope(previousStatus, status)) {
+                    this.invalidateAllowedPreviousVersions();
                     this.wrapInProgress(async () => await this.loadPreviousVersions());
                 }
                 break;
@@ -343,15 +348,44 @@ export class PublishingViewProvider extends WebviewBase<PublishingFields> {
             commands.executeCommand(EXTENSION_ENVIRONMENT_VIEW_VALIDATION_ACTION_NAME);
             return;
         }
-        const versions = await this.crudService
-            .getVersions(host, token, packageId, getPreviousVersionStatuses(status))
-            .then((dto) => dto.versions.map((version) => splitVersion(version.version).version))
-            .catch(() => [] as VersionId[]);
 
-        const options = Array.from(new Set([PUBLISHING_NO_PREVIOUS_VERSION, ...versions]));
-        this.allowedPreviousVersions = options;
-        this.sendPreviousVersionOptions(options, previousVersion, status);
-        this.updatePreviousVersionValidity(this.getPublishingViewData(this.workfolderService.activeWorkfolderPath));
+        this.setPreviousVersionsLoading(true);
+        try {
+            const dto = await this.crudService.getVersions(
+                host,
+                token,
+                packageId,
+                getPreviousVersionStatuses(status)
+            );
+            const versions = dto.versions.map((version) => splitVersion(version.version).version);
+
+            const options = Array.from(new Set([PUBLISHING_NO_PREVIOUS_VERSION, ...versions]));
+            this.allowedPreviousVersions = options;
+            this.sendPreviousVersionOptions(options, previousVersion, status);
+            this.updatePreviousVersionValidity(
+                this.getPublishingViewData(this.workfolderService.activeWorkfolderPath)
+            );
+        } catch (error) {
+            if ((error as CrudError).status === ABORTED_ERROR_CODE) {
+                return;
+            }
+            this.invalidateAllowedPreviousVersions();
+            window.showErrorMessage(PUBLISHING_PREVIOUS_VERSIONS_LOAD_ERROR);
+        } finally {
+            this.setPreviousVersionsLoading(false);
+        }
+    }
+
+    private invalidateAllowedPreviousVersions(): void {
+        this.allowedPreviousVersions = undefined;
+        this.updatePreviousVersionValidity(
+            this.getPublishingViewData(this.workfolderService.activeWorkfolderPath)
+        );
+    }
+
+    private setPreviousVersionsLoading(loading: boolean): void {
+        this.arePreviousVersionsLoading = loading;
+        this.updatePublishButtonState();
     }
 
 
@@ -380,7 +414,9 @@ export class PublishingViewProvider extends WebviewBase<PublishingFields> {
         const publishingData = this.getPublishingViewData(this.workfolderService.activeWorkfolderPath);
         this.updateWebviewDisable(
             PublishingFields.PUBLISHING_BUTTON,
-            this.dependentFieldsDisabled || this.isPreviousVersionInvalid(publishingData)
+            this.dependentFieldsDisabled ||
+                this.arePreviousVersionsLoading ||
+                this.isPreviousVersionInvalid(publishingData)
         );
     }
 
@@ -480,6 +516,10 @@ export class PublishingViewProvider extends WebviewBase<PublishingFields> {
             return;
         }
 
+        // The allowed set is still being loaded, so whether the selection is valid is not known yet.
+        if (this.arePreviousVersionsLoading) {
+            return;
+        }
         if (this.isPreviousVersionInvalid(data)) {
             this.updatePreviousVersionValidity(data);
             return;

--- a/src/common/webview/publishing-view.ts
+++ b/src/common/webview/publishing-view.ts
@@ -10,7 +10,11 @@ import {
 import { splitVersion } from '../../utils/files.utils';
 import { getCodicon, getElements, getJsScript, getNonce, getStyle } from '../../utils/html-content.builder';
 import { capitalize } from '../../utils/path.utils';
-import { convertOptionsToDto } from '../../utils/publishing.utils';
+import {
+    convertOptionsToDto,
+    getPreviousVersionStatuses,
+    hasSamePreviousVersionScope
+} from '../../utils/publishing.utils';
 import {
     ABORTED_ERROR_CODE,
     EXTENSION_ENVIRONMENT_VIEW_VALIDATION_ACTION_NAME,
@@ -21,7 +25,12 @@ import {
     PUBLISHING_INPUT_DEFAULT_PATTERN,
     PUBLISHING_JS_PATH,
     PUBLISHING_LOADING_OPTION,
+    PUBLISHING_NO_PREVIOUS_RELEASE_VERSION_TEXT,
     PUBLISHING_NO_PREVIOUS_VERSION,
+    PUBLISHING_NO_PREVIOUS_VERSION_TEXT,
+    PUBLISHING_PREVIOUS_RELEASE_VERSION_LABEL,
+    PUBLISHING_PREVIOUS_VERSION_LABEL,
+    PUBLISHING_RELEASE_PREVIOUS_VERSION_REQUIRED,
     PUBLISHING_STATUSES,
     PUBLISHING_WEBVIEW
 } from '../constants/publishing.constants';
@@ -48,6 +57,8 @@ import { debounce, isMatchingPattern } from '../../utils/common.utils';
 
 export class PublishingViewProvider extends WebviewBase<PublishingFields> {
     private readonly _publishingViewData: Map<WorkfolderPath, PublishingViewData> = new Map();
+    private allowedPreviousVersions: VersionId[] | undefined;
+    private dependentFieldsDisabled = true;
     private readonly updateLabelsDebounced = debounce((data: PublishingViewData, version: VersionId) =>
         this.wrapInProgress(async () => await this.updateLabels(data, version))
     );
@@ -160,6 +171,7 @@ export class PublishingViewProvider extends WebviewBase<PublishingFields> {
     private restoreLocalFields(workfolderPath: WorkfolderPath): void {
         const configurationFileLike = this.configurationFileService.getConfigurationFile(workfolderPath);
         this.restoreConfigPackageId(workfolderPath, configurationFileLike);
+        this.allowedPreviousVersions = undefined;
         const publishingData = this.getPublishingViewData(workfolderPath);
         const { packageId, version, status, previousVersion, labels } = publishingData;
         this.disableDependentFields(true);
@@ -170,10 +182,10 @@ export class PublishingViewProvider extends WebviewBase<PublishingFields> {
         this.updateWebviewField(PublishingFields.VERSION, version);
         this.updateWebviewField(PublishingFields.STATUS, status);
         this.updateVersionPattern(publishingData, status);
+        this.updatePreviousVersionWording(status);
 
         const options = Array.from(new Set([PUBLISHING_NO_PREVIOUS_VERSION, previousVersion])).filter((value) => !!value);
-        this.updateWebviewOptions(PublishingFields.PREVIOUS_VERSION, convertOptionsToDto(options, previousVersion));
-        this.updateWebviewField(PublishingFields.PREVIOUS_VERSION, previousVersion);
+        this.sendPreviousVersionOptions(options, previousVersion, status);
         this.updateWebviewLabels(labels);
     }
 
@@ -183,6 +195,7 @@ export class PublishingViewProvider extends WebviewBase<PublishingFields> {
         switch (payload.field) {
             case PublishingFields.PACKAGE_ID: {
                 publishingViewData.packageId = payload.value as PackageId;
+                this.allowedPreviousVersions = undefined;
                 this.disableDependentFields(true);
                 this.updatePackageIdDebounced(workfolderPath);
                 break;
@@ -195,12 +208,18 @@ export class PublishingViewProvider extends WebviewBase<PublishingFields> {
             }
             case PublishingFields.STATUS: {
                 const status: VersionStatus = payload.value as VersionStatus;
+                const previousStatus = publishingViewData.status;
                 publishingViewData.status = status;
                 this.updateVersionPattern(publishingViewData, status);
+                this.updatePreviousVersionWording(status);
+                if (!hasSamePreviousVersionScope(previousStatus, status)) {
+                    this.wrapInProgress(async () => await this.loadPreviousVersions());
+                }
                 break;
             }
             case PublishingFields.PREVIOUS_VERSION: {
                 publishingViewData.previousVersion = payload.value as string;
+                this.updatePreviousVersionValidity(publishingViewData);
                 break;
             }
             case PublishingFields.LABELS: {
@@ -217,10 +236,11 @@ export class PublishingViewProvider extends WebviewBase<PublishingFields> {
             PublishingFields.VERSION,
             PublishingFields.STATUS,
             PublishingFields.LABELS,
-            PublishingFields.PREVIOUS_VERSION,
-            PublishingFields.PUBLISHING_BUTTON
+            PublishingFields.PREVIOUS_VERSION
         ];
         fields.forEach((field) => this.updateWebviewDisable(field, disable));
+        this.dependentFieldsDisabled = disable;
+        this.updatePublishButtonState();
     }
 
     private disableAllFields(disable: boolean = true): void {
@@ -312,7 +332,9 @@ export class PublishingViewProvider extends WebviewBase<PublishingFields> {
     }
 
     private async loadPreviousVersions(): Promise<void> {
-        const { packageId, previousVersion } = this.getPublishingViewData(this.workfolderService.activeWorkfolderPath);
+        const { packageId, previousVersion, status } = this.getPublishingViewData(
+            this.workfolderService.activeWorkfolderPath
+        );
         if (!packageId) {
             return;
         }
@@ -321,18 +343,83 @@ export class PublishingViewProvider extends WebviewBase<PublishingFields> {
             commands.executeCommand(EXTENSION_ENVIRONMENT_VIEW_VALIDATION_ACTION_NAME);
             return;
         }
-        const options = [PUBLISHING_NO_PREVIOUS_VERSION];
+        const versions = await this.crudService
+            .getVersions(host, token, packageId, getPreviousVersionStatuses(status))
+            .then((dto) => dto.versions.map((version) => splitVersion(version.version).version))
+            .catch(() => [] as VersionId[]);
 
-        await this.crudService
-            .getVersions(host, token, packageId)
-            .then((dto) => options.push(...dto.versions.map((version) => splitVersion(version.version).version)))
-            .catch();
+        const options = Array.from(new Set([PUBLISHING_NO_PREVIOUS_VERSION, ...versions]));
+        this.allowedPreviousVersions = options;
+        this.sendPreviousVersionOptions(options, previousVersion, status);
+        this.updatePreviousVersionValidity(this.getPublishingViewData(this.workfolderService.activeWorkfolderPath));
+    }
 
-        this.updateWebviewOptions(PublishingFields.PREVIOUS_VERSION, convertOptionsToDto(options, previousVersion));
+
+    private isPreviousVersionInvalid({ previousVersion }: PublishingViewData): boolean {
+        if (!previousVersion || previousVersion === PUBLISHING_NO_PREVIOUS_VERSION) {
+            return false;
+        }
+        // Nothing loaded yet: staying silent avoids flagging an error before the options arrive.
+        if (!this.allowedPreviousVersions) {
+            return false;
+        }
+        return !this.allowedPreviousVersions.includes(previousVersion);
+    }
+
+    private updatePreviousVersionValidity(publishingData: PublishingViewData): void {
+        const invalid = this.isPreviousVersionInvalid(publishingData);
+        this.updateWebviewInvalid(PublishingFields.PREVIOUS_VERSION, invalid);
+        this.updateWebviewField(
+            PublishingFields.PREVIOUS_VERSION_GROUP,
+            invalid ? PUBLISHING_RELEASE_PREVIOUS_VERSION_REQUIRED : ''
+        );
+        this.updatePublishButtonState();
+    }
+
+    private updatePublishButtonState(): void {
+        const publishingData = this.getPublishingViewData(this.workfolderService.activeWorkfolderPath);
+        this.updateWebviewDisable(
+            PublishingFields.PUBLISHING_BUTTON,
+            this.dependentFieldsDisabled || this.isPreviousVersionInvalid(publishingData)
+        );
+    }
+
+    private sendPreviousVersionOptions(options: string[], previousVersion: VersionId, status: VersionStatus): void {
+        const optionsWithSelected =
+            previousVersion && !options.includes(previousVersion)
+                ? [options[0], previousVersion, ...options.slice(1)]
+                : options;
+
+        this.updateWebviewOptions(
+            PublishingFields.PREVIOUS_VERSION,
+            convertOptionsToDto(optionsWithSelected, previousVersion, this.getNoPreviousVersionLabels(status))
+        );
+        this.updateWebviewField(PublishingFields.PREVIOUS_VERSION, previousVersion);
     }
 
     private updateVersionPattern(publishingData: PublishingViewData, status: VersionStatus): void {
         this.updateWebviewPattern(PublishingFields.VERSION, this.getPattern(publishingData, status));
+    }
+
+    private getPreviousVersionWording(status: VersionStatus): { label: string; noPreviousVersion: string } {
+        return status === VersionStatus.DRAFT
+            ? {
+                  label: PUBLISHING_PREVIOUS_VERSION_LABEL,
+                  noPreviousVersion: PUBLISHING_NO_PREVIOUS_VERSION_TEXT
+              }
+            : {
+                  label: PUBLISHING_PREVIOUS_RELEASE_VERSION_LABEL,
+                  noPreviousVersion: PUBLISHING_NO_PREVIOUS_RELEASE_VERSION_TEXT
+              };
+    }
+
+    private updatePreviousVersionWording(status: VersionStatus): void {
+        const { label } = this.getPreviousVersionWording(status);
+        this.updateWebviewField(PublishingFields.PREVIOUS_VERSION_LABEL, label);
+    }
+
+    private getNoPreviousVersionLabels(status: VersionStatus): Record<string, string> {
+        return { [PUBLISHING_NO_PREVIOUS_VERSION]: this.getPreviousVersionWording(status).noPreviousVersion };
     }
 
     private deleteWebviewLabels(label: string): void {
@@ -390,6 +477,11 @@ export class PublishingViewProvider extends WebviewBase<PublishingFields> {
         }
         if (!previousVersion) {
             this.updateWebviewRequired(PublishingFields.PREVIOUS_VERSION);
+            return;
+        }
+
+        if (this.isPreviousVersionInvalid(data)) {
+            this.updatePreviousVersionValidity(data);
             return;
         }
 
@@ -469,10 +561,14 @@ export class PublishingViewProvider extends WebviewBase<PublishingFields> {
                         <vscode-label for="${PublishingFields.LABELS}" id="labelForLabels">Labels:</vscode-label>
                         <vscode-textfield id="${PublishingFields.LABELS}" placeholder="↵"></vscode-textfield>
                     </p>
-                    <p>
-                        <vscode-label for="${PublishingFields.PREVIOUS_VERSION}" required>Previous release version:</vscode-label>
-                        <vscode-single-select id="${PublishingFields.PREVIOUS_VERSION}" combobox>
-                            <vscode-option selected>${PUBLISHING_NO_PREVIOUS_VERSION}</vscode-option>
+                    <p id="${PublishingFields.PREVIOUS_VERSION_GROUP}">
+                        <vscode-label
+                            id="${PublishingFields.PREVIOUS_VERSION_LABEL}"
+                            for="${PublishingFields.PREVIOUS_VERSION}"
+                            required
+                        >${PUBLISHING_PREVIOUS_VERSION_LABEL}</vscode-label>
+                        <vscode-single-select title="A release version must have a release previous version" id="${PublishingFields.PREVIOUS_VERSION}" combobox>
+                            <vscode-option selected value="${PUBLISHING_NO_PREVIOUS_VERSION}">${PUBLISHING_NO_PREVIOUS_VERSION_TEXT}</vscode-option>
                         </vscode-single-select>
                     </p>
                     <p>

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -2,12 +2,6 @@ import * as path from 'path';
 
 import { runTests } from '@vscode/test-electron';
 
-// Kept in step with the `--code_version` passed to `extest` in the `test:ui` script, and within the
-// `vscode-min`/`vscode-max` range that vscode-extension-tester declares. Without a pin, every run
-// resolves to whatever stable release is current, so a VS Code release can break CI on its own and
-// the download cache key changes weekly.
-const VSCODE_VERSION = '1.131.0';
-
 // Idle timeout for the VS Code download. The default of 15 s aborts a ~300 MB transfer on the first
 // stall on a CI runner, and the built-in retries restart the file from scratch under the same limit.
 const DOWNLOAD_TIMEOUT_MS = 120_000;
@@ -24,7 +18,6 @@ async function main(): Promise<void> {
 
 		// Download VS Code, unzip it and run the integration test
 		await runTests({
-			version: VSCODE_VERSION,
 			timeout: DOWNLOAD_TIMEOUT_MS,
 			extensionDevelopmentPath,
 			extensionTestsPath,

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -14,8 +14,9 @@ async function main() {
 
 		// Download VS Code, unzip it and run the integration test
 		await runTests({ extensionDevelopmentPath, extensionTestsPath });
-	} catch {
+	} catch (error) {
 		console.error('Failed to run tests');
+		console.error(error);
 		process.exit(1);
 	}
 }

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -2,7 +2,17 @@ import * as path from 'path';
 
 import { runTests } from '@vscode/test-electron';
 
-async function main() {
+// Kept in step with the `--code_version` passed to `extest` in the `test:ui` script, and within the
+// `vscode-min`/`vscode-max` range that vscode-extension-tester declares. Without a pin, every run
+// resolves to whatever stable release is current, so a VS Code release can break CI on its own and
+// the download cache key changes weekly.
+const VSCODE_VERSION = '1.131.0';
+
+// Idle timeout for the VS Code download. The default of 15 s aborts a ~300 MB transfer on the first
+// stall on a CI runner, and the built-in retries restart the file from scratch under the same limit.
+const DOWNLOAD_TIMEOUT_MS = 120_000;
+
+async function main(): Promise<void> {
 	try {
 		// The folder containing the Extension Manifest package.json
 		// Passed to `--extensionDevelopmentPath`
@@ -13,7 +23,12 @@ async function main() {
 		const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
 		// Download VS Code, unzip it and run the integration test
-		await runTests({ extensionDevelopmentPath, extensionTestsPath });
+		await runTests({
+			version: VSCODE_VERSION,
+			timeout: DOWNLOAD_TIMEOUT_MS,
+			extensionDevelopmentPath,
+			extensionTestsPath,
+		});
 	} catch (error) {
 		console.error('Failed to run tests');
 		console.error(error);

--- a/src/ui-test/activityBar.test.ts
+++ b/src/ui-test/activityBar.test.ts
@@ -18,7 +18,7 @@ describe('Activity Bar Tests', () => {
 				return control.getTitle();
 			}),
 		);
-		expect(titles.some((title) => title === EXTENSION_NAME)).is.true;
+		expect(titles.some((title) => title.includes(EXTENSION_NAME)), `Titles: ${titles.join(', ')}`).is.true;
 	});
 
 	it('Get a extension view', async () => {

--- a/src/ui-test/publish.test.ts
+++ b/src/ui-test/publish.test.ts
@@ -16,7 +16,6 @@ import {
 } from 'vscode-extension-tester';
 import {
     PUBLISHING_INPUT_DEFAULT_PATTERN,
-    PUBLISHING_NO_PREVIOUS_RELEASE_VERSION_TEXT,
     PUBLISHING_NO_PREVIOUS_VERSION,
     PUBLISHING_NO_PREVIOUS_VERSION_TEXT,
     PUBLISHING_PREVIOUS_VERSION_LABEL,
@@ -70,8 +69,7 @@ import {
     getTextValue,
     getWebView,
     openSelect,
-    Until,
-    waitForTextValue
+    Until
 } from './utils/webview.utils';
 
 const LABELS_DATA: LabelData[] = [
@@ -533,8 +531,6 @@ describe('Publishing Tests', () => {
                     await clickOption(statusField, RELEASE);
 
                     await labelsField?.sendKeys('Publish-release-test' + Key.ENTER);
-
-                    await waitForTextValue(previousReleaseVersion, PUBLISHING_NO_PREVIOUS_RELEASE_VERSION_TEXT);
 
                     await clickOption(previousReleaseVersion, PUBLISHING_NO_PREVIOUS_VERSION);
 

--- a/src/ui-test/publish.test.ts
+++ b/src/ui-test/publish.test.ts
@@ -16,6 +16,7 @@ import {
 } from 'vscode-extension-tester';
 import {
     PUBLISHING_INPUT_DEFAULT_PATTERN,
+    PUBLISHING_NO_PREVIOUS_RELEASE_VERSION_TEXT,
     PUBLISHING_NO_PREVIOUS_VERSION,
     PUBLISHING_NO_PREVIOUS_VERSION_TEXT,
     PUBLISHING_PREVIOUS_VERSION_LABEL,
@@ -69,7 +70,8 @@ import {
     getTextValue,
     getWebView,
     openSelect,
-    Until
+    Until,
+    waitForTextValue
 } from './utils/webview.utils';
 
 const LABELS_DATA: LabelData[] = [
@@ -531,6 +533,9 @@ describe('Publishing Tests', () => {
                     await clickOption(statusField, RELEASE);
 
                     await labelsField?.sendKeys('Publish-release-test' + Key.ENTER);
+
+                    await waitForTextValue(previousReleaseVersion, PUBLISHING_NO_PREVIOUS_RELEASE_VERSION_TEXT);
+
                     await clickOption(previousReleaseVersion, PUBLISHING_NO_PREVIOUS_VERSION);
 
                     await publishingButton?.click();

--- a/src/ui-test/publish.test.ts
+++ b/src/ui-test/publish.test.ts
@@ -17,6 +17,8 @@ import {
 import {
     PUBLISHING_INPUT_DEFAULT_PATTERN,
     PUBLISHING_NO_PREVIOUS_VERSION,
+    PUBLISHING_NO_PREVIOUS_VERSION_TEXT,
+    PUBLISHING_PREVIOUS_VERSION_LABEL,
     STATUS_BAR_PUBLISH_MESSAGE
 } from '../common/constants/publishing.constants';
 import { EnvironmentWebviewFields } from '../common/models/environment.model';
@@ -75,7 +77,7 @@ const LABELS_DATA: LabelData[] = [
     { label: 'Version:', required: true },
     { label: 'Status:', required: true },
     { label: 'Labels:', required: false },
-    { label: 'Previous release version:', required: true }
+    { label: PUBLISHING_PREVIOUS_VERSION_LABEL, required: true }
 ];
 
 const DRAFT = 'Draft';
@@ -740,7 +742,7 @@ describe('Publishing Tests', () => {
     const validatePreviousVersionDefaultValue = async (): Promise<void> => {
         try {
             const previousReleaseVersionValue = await getTextValue(previousReleaseVersion);
-            expect(previousReleaseVersionValue).is.equals(PUBLISHING_NO_PREVIOUS_VERSION);
+            expect(previousReleaseVersionValue).is.equals(PUBLISHING_NO_PREVIOUS_VERSION_TEXT);
         } catch (error) {
             console.error('Error in Check "Previous Version" test:', error);
             throw error;

--- a/src/ui-test/utils/webview.utils.ts
+++ b/src/ui-test/utils/webview.utils.ts
@@ -84,9 +84,10 @@ export const clickOption = async (field: WebElement | undefined, name: string): 
     const options = await getSingleSelectOptions(field);
     const option = await findAsync(options, async (option) => (await option.getText()) === name);
     if (!option) {
-        return field?.click();
+        await closeSelect(field);
+        throw new Error(`Option "${name}" was not found. Available options: ${(await getTexts(options)).join(', ')}`);
     }
-    await option?.click();
+    await option.click();
 };
 
 export const findAsync = async <T>(array: T[], predicate: (item: T) => Promise<boolean>): Promise<T | undefined> => {
@@ -110,6 +111,28 @@ export const getTextValue = async (field: WebElement | undefined): Promise<strin
     const shadowRoot = await field?.getShadowRoot();
     const textField = await shadowRoot?.findElement(By.css('input'));
     return (await textField?.getAttribute('value')) ?? undefined;
+};
+
+/**
+ * Waits until the field displays `expected`.
+ *
+ * Changing the publishing status reloads the previous-version list from the backend and re-renders
+ * the combobox once the response lands. The displayed value is written by that same update, so it
+ * is a direct signal that the list has settled — unlike a fixed delay, which either slows the run
+ * down or still loses the race on a slow runner.
+ */
+export const waitForTextValue = async (
+    field: WebElement | undefined,
+    expected: string,
+    timeout: number = 10000
+): Promise<void> => {
+    await field
+        ?.getDriver()
+        .wait(
+            async () => (await getTextValue(field)) === expected,
+            timeout,
+            `Field did not display "${expected}" within ${timeout} ms`
+        );
 };
 
 export const openSelect = async (field: WebElement | undefined): Promise<void> => {

--- a/src/ui-test/utils/webview.utils.ts
+++ b/src/ui-test/utils/webview.utils.ts
@@ -109,7 +109,7 @@ export const getTexts = async (fields: WebElement[]): Promise<string[]> => {
 export const getTextValue = async (field: WebElement | undefined): Promise<string | undefined> => {
     const shadowRoot = await field?.getShadowRoot();
     const textField = await shadowRoot?.findElement(By.css('input'));
-    return textField?.getAttribute('value');
+    return (await textField?.getAttribute('value')) ?? undefined;
 };
 
 export const openSelect = async (field: WebElement | undefined): Promise<void> => {

--- a/src/ui-test/utils/webview.utils.ts
+++ b/src/ui-test/utils/webview.utils.ts
@@ -79,15 +79,42 @@ export const getSingleSelectOptions = async (field: WebElement | undefined): Pro
     return options;
 };
 
-export const clickOption = async (field: WebElement | undefined, name: string): Promise<void> => {
-    await field?.click();
-    const options = await getSingleSelectOptions(field);
-    const option = await findAsync(options, async (option) => (await option.getText()) === name);
-    if (!option) {
+/**
+ * Selects the option with the given text, waiting for it to appear.
+ *
+ * The wait matters because changing the publishing status reloads the previous-version list from
+ * the backend and replaces the options once the response lands. Reading them once races that
+ * update, and the previous behaviour on a miss — clicking the field again — left the select open,
+ * where it later intercepted a click meant for another element.
+ */
+export const clickOption = async (
+    field: WebElement | undefined,
+    name: string,
+    timeout: number = 10000
+): Promise<void> => {
+    await openSelect(field);
+
+    let availableOptions: string[] = [];
+    let option: WebElement | undefined;
+
+    try {
+        option = await field?.getDriver().wait(async () => {
+            try {
+                const options = await getSingleSelectOptions(field);
+                availableOptions = await getTexts(options);
+                return await findAsync(options, async (option) => (await option.getText()) === name);
+            } catch {
+                return undefined;
+            }
+        }, timeout);
+    } catch {
         await closeSelect(field);
-        throw new Error(`Option "${name}" was not found. Available options: ${(await getTexts(options)).join(', ')}`);
+        throw new Error(
+            `Option "${name}" did not appear within ${timeout} ms. Available options: ${availableOptions.join(', ')}`
+        );
     }
-    await option.click();
+
+    await option?.click();
 };
 
 export const findAsync = async <T>(array: T[], predicate: (item: T) => Promise<boolean>): Promise<T | undefined> => {
@@ -111,28 +138,6 @@ export const getTextValue = async (field: WebElement | undefined): Promise<strin
     const shadowRoot = await field?.getShadowRoot();
     const textField = await shadowRoot?.findElement(By.css('input'));
     return (await textField?.getAttribute('value')) ?? undefined;
-};
-
-/**
- * Waits until the field displays `expected`.
- *
- * Changing the publishing status reloads the previous-version list from the backend and re-renders
- * the combobox once the response lands. The displayed value is written by that same update, so it
- * is a direct signal that the list has settled — unlike a fixed delay, which either slows the run
- * down or still loses the race on a slow runner.
- */
-export const waitForTextValue = async (
-    field: WebElement | undefined,
-    expected: string,
-    timeout: number = 10000
-): Promise<void> => {
-    await field
-        ?.getDriver()
-        .wait(
-            async () => (await getTextValue(field)) === expected,
-            timeout,
-            `Field did not display "${expected}" within ${timeout} ms`
-        );
 };
 
 export const openSelect = async (field: WebElement | undefined): Promise<void> => {

--- a/src/utils/publishing.utils.ts
+++ b/src/utils/publishing.utils.ts
@@ -1,12 +1,30 @@
 import { VersionStatus } from '../common/models/publishing.model';
 import { WebviewOption } from '../common/models/webview.model';
 
+export const getPreviousVersionStatuses = (status: VersionStatus): VersionStatus[] => {
+    switch (status) {
+        case VersionStatus.DRAFT:
+            return [VersionStatus.RELEASE, VersionStatus.DRAFT];
+        case VersionStatus.RELEASE:
+        case VersionStatus.ARCHIVED:
+            return [VersionStatus.RELEASE];
+        default:
+            return assertUnreachableStatus(status);
+    }
+};
 
-export const getPreviousVersionStatuses = (status: VersionStatus): VersionStatus[] =>
-    status === VersionStatus.DRAFT ? [VersionStatus.RELEASE, VersionStatus.DRAFT] : [VersionStatus.RELEASE];
+export const hasSamePreviousVersionScope = (one: VersionStatus, another: VersionStatus): boolean => {
+    const oneStatuses = getPreviousVersionStatuses(one);
+    const anotherStatuses = getPreviousVersionStatuses(another);
+    return (
+        oneStatuses.length === anotherStatuses.length &&
+        oneStatuses.every((status) => anotherStatuses.includes(status))
+    );
+};
 
-export const hasSamePreviousVersionScope = (one: VersionStatus, another: VersionStatus): boolean =>
-    (one === VersionStatus.DRAFT) === (another === VersionStatus.DRAFT);
+const assertUnreachableStatus = (status: never): never => {
+    throw new Error(`Unhandled version status: ${status}`);
+};
 
 export const convertOptionsToDto = (
     options: string[],

--- a/src/utils/publishing.utils.ts
+++ b/src/utils/publishing.utils.ts
@@ -1,11 +1,27 @@
+import { VersionStatus } from '../common/models/publishing.model';
 import { WebviewOption } from '../common/models/webview.model';
 
-export const convertOptionsToDto = (options: string[], selected: string): WebviewOption[] => {
+
+export const getPreviousVersionStatuses = (status: VersionStatus): VersionStatus[] =>
+    status === VersionStatus.DRAFT ? [VersionStatus.RELEASE, VersionStatus.DRAFT] : [VersionStatus.RELEASE];
+
+export const hasSamePreviousVersionScope = (one: VersionStatus, another: VersionStatus): boolean =>
+    (one === VersionStatus.DRAFT) === (another === VersionStatus.DRAFT);
+
+export const convertOptionsToDto = (
+    options: string[],
+    selected: string,
+    labels?: Record<string, string>
+): WebviewOption[] => {
     return (
-        options.map((option) => ({
-            name: option,
-            disabled: false,
-            selected: selected ? option === selected : false
-        })) ?? []
+        options.map((option) => {
+            const label = labels?.[option];
+            return {
+                name: option,
+                disabled: false,
+                selected: selected ? option === selected : false,
+                ...(label ? { label } : {})
+            };
+        }) ?? []
     );
 };


### PR DESCRIPTION
## Summary

Aligns the VS Code extension publish webview with backend previous-version status rules introduced in
[Netcracker/qubership-apihub-backend#322](https://github.com/Netcracker/qubership-apihub-backend/issues/322).

Closes [Netcracker/qubership-apihub#709](https://github.com/Netcracker/qubership-apihub/issues/709).

Companion UI change: [Netcracker/qubership-apihub-ui#302](https://github.com/Netcracker/qubership-apihub-ui/pull/302).

When publishing from the extension, the webview now enforces the same previous-version status rules as
the backend:

- **Release** versions must reference a **release** previous version.
- **Draft** versions may reference a previous version in **draft** or **release** status.
- Changing the target status to **release** re-validates the selected previous version and blocks
  publish when the combination is invalid.

## Changes

### Validation helpers (`publishing.utils.ts`)
- Add `getPreviousVersionStatuses` to determine which version statuses to fetch for the previous-version
  dropdown based on the selected target status.
- Add `hasSamePreviousVersionScope` to detect when a status change requires reloading previous-version
  options.
- Extend `convertOptionsToDto` with optional display labels (e.g. status-aware “No previous version”
  text).

### Publish webview (`publishing-view.ts`)
- Load previous versions filtered by target status instead of always fetching release-only versions.
- Track the allowed previous-version set and validate the current selection against it.
- Reload previous-version options when status changes across a different scope (draft ↔ release/archive).
- Update field labels dynamically:
  - **Draft:** “Previous version” / “No previous version”
  - **Release / archived:** “Previous release version” / “No previous release version”
- Show validation feedback when a release version has a non-release previous version:
  - mark the previous-version control as invalid
  - show “A release version must have a release previous version” as a tooltip on the field group
  - disable the Publish button
- Block publish while previous versions are loading or when the load fails.
- Show an error notification if the previous-version list cannot be loaded.

### API layer (`crud.service.ts`)
- `getVersions` accepts `statuses: VersionStatus[]` and passes them as a comma-separated query
  parameter.

### Webview template and JS
- Support optional `label` on dropdown options (`main.js`).
- Add webview field handlers for dynamic previous-version label and validation tooltip
  (`publishing.js`).
- Update HTML markup with separate label and group elements for the previous-version field.

### Constants and models
- Add shared user-facing strings for labels, validation message, and load error.
- Extend `PublishingFields` and `WebviewOption` for the new webview fields.

## Test plan

- [ ] **Publish (release):** previous-version dropdown lists only release versions.
- [ ] **Publish (draft):** previous-version dropdown lists both draft and release versions.
- [ ] **Status switch:** select a draft previous version, change target status to release — field is
  marked invalid, tooltip shows “A release version must have a release previous version”, Publish is
  disabled.
- [ ] **Status switch back:** change target status back to draft — validation clears, Publish
  re-enables.
- [ ] **Status switch (same scope):** changing between release and archived does not unnecessarily
  reload previous-version options.
- [ ] **Package change:** changing package ID clears cached allowed versions and reloads options for
  the new package.
- [ ] **Loading state:** Publish stays disabled while previous versions are being fetched.
- [ ] **Load failure:** API error shows “Failed to load the list of previous versions…” notification.
- [ ] **Labels:** draft uses “Previous version”; release uses “Previous release version”.
- [ ] **Regression:** normal publish flow still works when a valid previous version is selected.